### PR TITLE
Add a "MM/DD/YYYY" date format support

### DIFF
--- a/status.go
+++ b/status.go
@@ -24,6 +24,8 @@ var (
 		// TODO(mdlayher): find a way to always determine if the output is
 		// month-first or day-first.
 		"02/01/06",
+		// Also new apcdupd's format
+		"01/02/2006",
 	}
 
 	// errInvalidKeyValuePair is returned when a message is not in the expected

--- a/status_test.go
+++ b/status_test.go
@@ -64,6 +64,13 @@ func TestStatus_parseKV(t *testing.T) {
 			},
 		},
 		{
+			desc: "OK time.Time(4)",
+			kv:   "BATTDATE : 11/14/2019",
+			s: &Status{
+				BatteryDate: time.Date(2019, time.November, 14, 0, 0, 0, 0, time.UTC),
+			},
+		},
+		{
 			desc: "N/A time.Time",
 			kv:   "XOFFBATT : N/A",
 			s: &Status{


### PR DESCRIPTION
The BATTDATE parameter was changed in apcupsd version 3.14.15-5 again. Right now it's look like this:

```
REG3     : 0x00
MANDATE  : 11/14/2019
SERIALNO : AS1943175
BATTDATE : 11/14/2019
NOMOUTV  : 230 Volts

```
And, of course, I got a follow error message:

`apcupsd-exporter[59274]: 2020/01/28 05:43:31 [ERROR] failed collecting UPS metric Desc{fqName: "apcupsd_battery_volts", help: "Current UPS battery voltage.", constLabels: {}, variableLabels: [hostname ups_name model]}: invalid time duration`

It's need to fix with compatibility to both versions of this parameters.
Old: MM/DD/YY
New: MM/DD/YYYY

Tech info:

```
rpm -qa | grep apc
apcupsd-3.14.14-5.el7.x86_64
# cat /etc/redhat-release 
CentOS Linux release 7.6.1810 (Core)
```
