### PR TITLE
Fix ALARMDEL parsing - include cases for 'Low Battery' and 'Always'

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,3 @@
 
 Package `apcupsd` provides a client for the [apcupsd](http://www.apcupsd.org/)
 Network Information Server (NIS).  MIT Licensed.
-
-Fork notes: this fork fixes a bug in which alternate values for ALARMDEL break the ability to parse the APC UPS daemon's response. If this bug is fixed in the central repo, there should be no reason not to use it instead. 

--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@
 
 Package `apcupsd` provides a client for the [apcupsd](http://www.apcupsd.org/)
 Network Information Server (NIS).  MIT Licensed.
+
+Fork notes: this fork fixes a bug in which alternate values for ALARMDEL break the ability to parse the APC UPS daemon's response. If this bug is fixed in the central repo, there should be no reason not to use it instead. 

--- a/status.go
+++ b/status.go
@@ -286,8 +286,9 @@ func (s *Status) parseKVDuration(k string, v string) (bool, error) {
 	case keyMaxTime:
 		s.MaximumTime, err = parse()
 	case keyAlarmDel:
-		// No alarm delay configured.
-		if v == "No alarm" {
+		valueText := strings.ToLower(v)
+		// When no alarm delay duration is set, don't attempt to parse a number.
+		if valueText == "no alarm" || valueText == "low battery" || valueText == "always" {
 			break
 		}
 


### PR DESCRIPTION
This PR addresses #10. APC UPS can return two values that are not currently handled that aren't time durations for `ALARMDEL`, which are 'Low Battery' and 'Always', indicating that no 'delay' will occur before sounding an alarm, but rather, it will happen immediately upon power failure, or immediately upon low battery. 

I figured the simplest fix is to treat this as if no parseable 'duration' exists to be parsed. If this logic should be changed, let me know. As telegraf doesn't use the `ALARMDEL` value, it wasn't important for our uses but if we want to represent these two alternate `ALARMDEL` possibilities in a different way, that's fine.

Thanks!