### PR TITLE
support time as returned by the older apcupsd as a fallback

### DIFF
--- a/status.go
+++ b/status.go
@@ -389,6 +389,9 @@ func parseOptionalTime(value string) (time.Time, error) {
 	if time, err := time.Parse(timeFormatLong, value); err == nil {
 		return time, nil
 	}
+	if time, err := time.Parse(time.UnixDate, value); err == nil {
+		return time, nil
+	}
 
 	return time.Time{}, fmt.Errorf("can't parse time: %q", value)
 }


### PR DESCRIPTION
I have a really old `apcupsd` on my NAS and don't feel like updating it at the moment… the older versions of `apcupsd` (prior to 3.14.8 I believe) return different times, e.g.

```
DATE     : Tue Aug 30 14:46:57 CEST 2022
```

this patch should make the client fallback to parsing this time should the simplified ISO parsing fail.